### PR TITLE
Remove invalid batches from pending pool

### DIFF
--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -67,6 +67,8 @@ pub struct CandidateBlock {
     pending_batch_ids: HashSet<String>,
     injected_batch_ids: HashSet<String>,
 
+    invalid_batch_ids: HashSet<String>,
+
     committed_txn_cache: TransactionCommitCache,
 }
 
@@ -99,6 +101,8 @@ impl CandidateBlock {
             pending_batches: vec![],
             pending_batch_ids: HashSet::new(),
             injected_batch_ids: HashSet::new(),
+
+            invalid_batch_ids: HashSet::new(),
         }
     }
 
@@ -377,11 +381,6 @@ impl CandidateBlock {
         let mut bad_batches = vec![];
         let mut pending_batches = vec![];
 
-        if self.injected_batch_ids == valid_batch_ids {
-            // There only injected batches in this block
-            return Ok(None);
-        }
-
         for batch in self.pending_batches.clone() {
             let header_signature = &batch.header_signature.clone();
             if batch.trace {
@@ -426,10 +425,17 @@ impl CandidateBlock {
                     committed_txn_cache.add_batch(&batch.clone());
                 }
             } else {
+                self.invalid_batch_ids.insert(batch.header_signature.clone());
                 bad_batches.push(batch.clone());
                 debug!("Batch {} invalid, not added to block", header_signature);
             }
         }
+
+        if self.injected_batch_ids == valid_batch_ids {
+            // There only injected batches in this block
+            return Ok(None);
+        }
+
         if execution_results.ending_state_hash.is_none() || self.no_batches_added(&builder) {
             debug!("Abandoning block, no batches added");
             return Ok(None);
@@ -526,5 +532,13 @@ impl CandidateBlock {
         } else {
             Err(CandidateBlockError::BlockEmpty)
         }
+    }
+
+    pub fn has_invalid_batches(&self) -> bool {
+        return !self.invalid_batch_ids.is_empty();
+    }
+
+    pub fn get_invalid_batch_ids(&self) -> &HashSet<String> {
+        return &self.invalid_batch_ids;
     }
 }

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -382,11 +382,10 @@ impl SyncBlockPublisher {
 
         if let Some(previous_block) = state.candidate_block.as_ref().map(|candidate| {
             self.get_block(&candidate.previous_block_id())
-                .expect("Failed to get previous block, but we are building on it.")
         }) {
-            self.cancel_block(state, false);
+            self.cancel_block(state);
 
-            if let Err(err) = self.initialize_block(state, &previous_block, false) {
+            if let Err(err) = self.initialize_block(state, &previous_block) {
                 error!("Initialization failed unexpectedly: {:?}", err);
             }
         }
@@ -483,7 +482,7 @@ impl SyncBlockPublisher {
         }
     }
 
-    fn cancel_block(&self, state: &mut BlockPublisherState, unref_block: bool) {
+    fn cancel_block(&self, state: &mut BlockPublisherState) {
         state.purge_invalid_txns();
 
         let mut candidate_block = None;


### PR DESCRIPTION
Ported changes from https://github.com/hyperledger/sawtooth-core/pull/1994 to our fork. This fixes the bug when invalid batches never go to the `INVALID` state until a new block arrives.